### PR TITLE
Fixed issue #26 with startPreview on Api Level 9

### DIFF
--- a/CAMView/src/main/java/eu/livotov/labs/android/camview/CameraLiveView.java
+++ b/CAMView/src/main/java/eu/livotov/labs/android/camview/CameraLiveView.java
@@ -3,6 +3,7 @@ package eu.livotov.labs.android.camview;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Configuration;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.SurfaceHolder;
@@ -67,8 +68,26 @@ public class CameraLiveView extends FrameLayout implements SurfaceHolder.Callbac
     private void initUI()
     {
         surfaceView = new SurfaceView(getContext());
+        //should be adjusted before surface is added to view
+        if (Build.VERSION.SDK_INT < 11)
+        {
+            adjustSurfaceHolderPre11();
+        }
         surfaceView.getHolder().addCallback(this);
         addView(surfaceView);
+    }
+
+    @TargetApi(10)
+    private void adjustSurfaceHolderPre11()
+    {
+        try
+        {
+            // only to address some old devices weird compat issues
+            surfaceView.getHolder().setType(SurfaceHolder.SURFACE_TYPE_PUSH_BUFFERS);
+        }
+        catch (Throwable ignored)
+        {
+        }
     }
 
     /**

--- a/CAMView/src/main/java/eu/livotov/labs/android/camview/camera/v1/DefaultCameraV1Controller.java
+++ b/CAMView/src/main/java/eu/livotov/labs/android/camview/camera/v1/DefaultCameraV1Controller.java
@@ -1,9 +1,7 @@
 package eu.livotov.labs.android.camview.camera.v1;
 
-import android.annotation.TargetApi;
 import android.graphics.ImageFormat;
 import android.hardware.Camera;
-import android.os.Build;
 import android.util.Log;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
@@ -125,11 +123,6 @@ public class DefaultCameraV1Controller extends AbstractController implements Cam
                 }
             }
 
-            if (Build.VERSION.SDK_INT < 11)
-            {
-                adjustSurfaceHolderPre11();
-            }
-
             if (surfaceHolder == null || surfaceHolder != surfaceView.getHolder())
             {
                 surfaceHolder = surfaceView.getHolder();
@@ -140,19 +133,6 @@ public class DefaultCameraV1Controller extends AbstractController implements Cam
             CameraUtilsV1.setupSurfaceAndCameraForPreview(Integer.parseInt(camera.getCameraId()), rawCameraObject, surfaceView);
             rawCameraObject.startPreview();
             rechargePreviewBuffer();
-        }
-    }
-
-    @TargetApi(10)
-    private void adjustSurfaceHolderPre11()
-    {
-        try
-        {
-            // only to address some old devices weird compat issues
-            surfaceHolder.setType(SurfaceHolder.SURFACE_TYPE_PUSH_BUFFERS);
-        }
-        catch (Throwable ignored)
-        {
         }
     }
 

--- a/CAMViewTestApp/src/main/res/values/strings.xml
+++ b/CAMViewTestApp/src/main/res/values/strings.xml
@@ -8,6 +8,6 @@
     <string name="camera_status_err">Camera Error: %s</string>
     <string name="camera_open_err">Camera Open Error: %s</string>
     <string name="camera_status_stopped">Camera Stopped...</string>
-    <string name="toogle_flash">Toggle Flash</string>
+    <string name="toggle_flash">Toggle Flash</string>
 
 </resources>


### PR DESCRIPTION
I fixed the error with api level 9. The  adjustSurfaceHolderPre11() was added to late to the surfaceholder. It must be added before the surface is added to the view. Now it works with the ideos x3.

I fixed also the breaking build (typo was corrected in layout but not in strings.xml) which was added by Livin21 from his last pull request.
